### PR TITLE
email/username now downcased by default to avoid case sensitivity

### DIFF
--- a/lib/user.rb
+++ b/lib/user.rb
@@ -14,9 +14,9 @@ class User
   def self.create(username:, password:, email:)
     encrypted_password = BCrypt::Password.create(password)
     result = DatabaseConnection.query("INSERT INTO users (username, password, email)
-                              VALUES ('#{username}', '#{encrypted_password}', '#{email}')
-                              RETURNING id;")
-    User.new(user_id: result[0]["id"], username: username, email: email)
+                              VALUES ('#{username.downcase}', '#{encrypted_password}', '#{email.downcase}')
+                              RETURNING id, username, email;")
+    User.new(user_id: result[0]["id"], username: result[0]["username"], email: result[0]["email"])
   end
 
   def self.find(user_id:)
@@ -27,7 +27,7 @@ class User
 
   def self.authenticate(email:, password:)
     user_info = DatabaseConnection.query("SELECT * FROM users
-                                 WHERE email = '#{email}';")
+                                 WHERE email = '#{email.downcase}';")
     return false unless user_info.cmd_tuples > 0 # nb that cmd_tuples is a pg object attribute for the number of database lines returned
     return false unless BCrypt::Password.new(user_info[0]["password"]) == password # nb might cause a problem if email's not unique
     User.new(user_id: user_info[0]["id"], username: user_info[0]["username"], email: email)

--- a/spec/unit/user_spec.rb
+++ b/spec/unit/user_spec.rb
@@ -55,6 +55,14 @@ describe User do
       expect(test_user.username).to eq(returned_user.username)
       expect(test_user.email).to eq(returned_user.email)
     end
+
+    it "Ensures email/username is not case sensitive" do
+      test_user = User.create(username: "tEsTy", password: "123password", email: "testymctesterson@test.org")
+      returned_user = User.authenticate(email: "tEsTyMcTeStErSon@TeSt.OrG", password: "123password")
+      expect(test_user.user_id).to eq(returned_user.user_id)
+      expect(test_user.username).to eq(returned_user.username.downcase)
+      expect(test_user.email).to eq(returned_user.email.downcase)
+    end
   end
 
 end


### PR DESCRIPTION
added test and very minor change to User class to ensure usernames or emails won't be case sensitive